### PR TITLE
Add fileExtensions to config, includes to paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,12 @@
 I'm trying to figure out how to set `include_path` when running PHPStan,
 so that PHPStan recognizes functions `require`d from files in `includes/`.
 
+## Solution
+
+See #2.
+
+## Testing of original issue
+
 Here's what I get in my minimal testing:
 
 ## Using `php.ini`

--- a/foo.php
+++ b/foo.php
@@ -3,5 +3,7 @@
 require_once 'bar.inc';
 
 bar();
+baz();
+print($asdf);
 
 ?>

--- a/includes/bar.inc
+++ b/includes/bar.inc
@@ -2,6 +2,8 @@
 
 function bar() {
   print("BAR");
+  print($foo);
+  baz();
 }
 
 ?>

--- a/php.ini
+++ b/php.ini
@@ -1,1 +1,0 @@
-include_path = "/app/includes"

--- a/phpstan
+++ b/phpstan
@@ -1,9 +1,3 @@
 #!/bin/sh
 
-if [ "$1" = "ini" ]; then
-  echo "Using php.ini to set include_path"
-  docker run --rm -v $PWD:/app --workdir /app --entrypoint php ghcr.io/phpstan/phpstan -c /app/php.ini /composer/vendor/bin/phpstan analyse
-else
-  echo "Using bootstrap file to set include_path"
-  docker run --rm -v $PWD:/app --workdir /app ghcr.io/phpstan/phpstan analyse --autoload-file /app/phpstan-bootstrap.php
-fi
+docker run --rm -v $PWD:/app --workdir /app ghcr.io/phpstan/phpstan analyse

--- a/phpstan-bootstrap.php
+++ b/phpstan-bootstrap.php
@@ -1,2 +1,0 @@
-<?php
-set_include_path("/app/includes");

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,4 +1,8 @@
 parameters:
-    level: 0
+    level: 5
     paths:
         - foo.php
+        - includes
+    fileExtensions:
+        - php
+        - inc


### PR DESCRIPTION
- Adding `includes/` to `paths` ensures that that code is also
  checked for issues
- Adding `fileExtensions` with `inc` as an entry ensures that
  PHPStan looks at `.inc` files

Removed code that was testing alternative approaches.

Result is what I'd expect:

```
➜ ./phpstan
Note: Using configuration file /app/phpstan.neon.
 2/2 [▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓] 100%

 ------ --------------------------------------------------------------------- 
  Line   foo.php                                                              
 ------ --------------------------------------------------------------------- 
  6      Function baz not found.                                              
         💡 Learn more at https://phpstan.org/user-guide/discovering-symbols   
  7      Variable $asdf might not be defined.                                 
 ------ --------------------------------------------------------------------- 

 ------ --------------------------------------------------------------------- 
  Line   includes/bar.inc                                                     
 ------ --------------------------------------------------------------------- 
  5      Undefined variable: $foo                                             
  6      Function baz not found.                                              
         💡 Learn more at https://phpstan.org/user-guide/discovering-symbols   
 ------ --------------------------------------------------------------------- 

 [ERROR] Found 4 errors   
```